### PR TITLE
Fix dead powerpill link

### DIFF
--- a/index-ja.html
+++ b/index-ja.html
@@ -153,7 +153,7 @@ aria2 は RPC インターフェースをサポートしていて, aria2 プロ�
 
 <ul>
 <li><a href="https://github.com/tatsuhiro-t/apt-metalink"><strong>apt-metalink</strong></a>: Faster package downloads for Debian/Ubuntu</li>
-<li><a href="http://xyne.archlinux.ca/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
+<li><a href="https://xyne.dev/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
 <li><a href="http://xyne.archlinux.ca/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
 <li><a href="https://github.com/sonnyp/aria2.js"><strong>aria2.js</strong></a>: JavaScript (browsers and Node.js) library and cli for aria2 RPC</li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@ and XML-RPC.</p></li>
 
 <ul>
 <li><a href="https://github.com/tatsuhiro-t/apt-metalink"><strong>apt-metalink</strong></a>: Faster package downloads for Debian/Ubuntu</li>
-<li><a href="http://xyne.archlinux.ca/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
+<li><a href="https://xyne.dev/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
 <li><a href="http://xyne.archlinux.ca/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
 <li><a href="https://github.com/sonnyp/aria2.js"><strong>aria2.js</strong></a>: JavaScript (browsers and Node.js) library and cli for aria2 RPC</li>
 </ul>


### PR DESCRIPTION
The `powerpill` link provided in the documentation is dead:

![image](https://user-images.githubusercontent.com/55339220/186869695-f00bc5d1-51b8-4c3b-ab9e-3581d246434c.png)

I got the new upstream link from https://wiki.archlinux.org/title/Powerpill