### PR TITLE
Updated xyne.archlinux.ca domain to xyne.dev

### DIFF
--- a/index-ja.html
+++ b/index-ja.html
@@ -153,8 +153,8 @@ aria2 は RPC インターフェースをサポートしていて, aria2 プロ�
 
 <ul>
 <li><a href="https://github.com/tatsuhiro-t/apt-metalink"><strong>apt-metalink</strong></a>: Faster package downloads for Debian/Ubuntu</li>
-<li><a href="http://xyne.archlinux.ca/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
-<li><a href="http://xyne.archlinux.ca/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
+<li><a href="http://xyne.dev/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
+<li><a href="http://xyne.dev/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
 <li><a href="https://github.com/sonnyp/aria2.js"><strong>aria2.js</strong></a>: JavaScript (browsers and Node.js) library and cli for aria2 RPC</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -166,8 +166,8 @@ and XML-RPC.</p></li>
 
 <ul>
 <li><a href="https://github.com/tatsuhiro-t/apt-metalink"><strong>apt-metalink</strong></a>: Faster package downloads for Debian/Ubuntu</li>
-<li><a href="http://xyne.archlinux.ca/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
-<li><a href="http://xyne.archlinux.ca/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
+<li><a href="http://xyne.dev/projects/powerpill/"><strong>powerpill</strong></a>: Pacman wrapper for parallel and segmented downloads.</li>
+<li><a href="http://xyne.dev/projects/python3-aria2jsonrpc/"><strong>python3-aria2jsonrpc</strong></a>: A wrapper class around Aria2&rsquo;s JSON RPC interface.</li>
 <li><a href="https://github.com/sonnyp/aria2.js"><strong>aria2.js</strong></a>: JavaScript (browsers and Node.js) library and cli for aria2 RPC</li>
 </ul>
 


### PR DESCRIPTION
Issue: #13 

updated `xyne.archlinux.ca` domain to `xyne.dev`